### PR TITLE
修复对x86_64和arm64的支持

### DIFF
--- a/build_vdso/src/gen_api.rs
+++ b/build_vdso/src/gen_api.rs
@@ -1,4 +1,4 @@
-use std::{fmt::format, fs, path::Path};
+use std::{fs, path::Path};
 
 use xmas_elf::symbol_table::Entry;
 

--- a/build_vdso/src/gen_wrapper.rs
+++ b/build_vdso/src/gen_wrapper.rs
@@ -21,7 +21,7 @@ name = "vdso_wrapper"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["staticlib"]
 
 [profile.dev]
 panic = "abort"

--- a/build_vdso/src/lib.rs
+++ b/build_vdso/src/lib.rs
@@ -44,12 +44,32 @@ pub fn build_vdso(config: &BuildConfig) {
     let linker_script = gen_linker_script(&config.arch);
     fs::write(&out_path, &linker_script).unwrap();
 
-    // 生成wrapper cdylib
+    // 生成wrapper静态库
     gen_wrapper(config);
 
     build_so(config);
 
     gen_api(config);
+}
+
+// 选择编译目标三元组
+fn build_target(arch: &str) -> &'static str {
+    match arch {
+        "x86_64" => "x86_64-unknown-none",
+        "aarch64" => "aarch64-unknown-none",
+        "riscv64" => "riscv64gc-unknown-none-elf",
+        _ => panic!("Unsupported arch"),
+    }
+}
+
+// 选择链接器程序
+fn linker_program(arch: &str) -> &'static str {
+    match arch {
+        "x86_64" => "x86_64-linux-musl-ld",
+        "aarch64" => "aarch64-linux-musl-ld",
+        "riscv64" => "riscv64-linux-musl-ld",
+        _ => panic!("Unsupported arch"),
+    }
 }
 
 /// 生成链接脚本的代码
@@ -62,108 +82,101 @@ fn gen_linker_script(arch: &str) -> String {
         _ => panic!("Unsupported arch"),
     };
     let linker = format!(
-        r#"
-    OUTPUT_ARCH({})
+r#"OUTPUT_ARCH({})
 
-    SECTIONS {{
-        . = SIZEOF_HEADERS;
+SECTIONS {{
+    . = SIZEOF_HEADERS;
 
-        /* 先放置动态链接相关的只读段 */
-        .hash		: {{ *(.hash) }}
-    	.gnu.hash	: {{ *(.gnu.hash) }}
-    	.dynsym		: {{ *(.dynsym) }}
-    	.dynstr		: {{ *(.dynstr) }}
-    	.gnu.version	: {{ *(.gnu.version) }}
-    	.gnu.version_d	: {{ *(.gnu.version_d) }}
-    	.gnu.version_r	: {{ *(.gnu.version_r) }}
+    /* 先放置动态链接相关的只读段 */
+    .hash		: {{ *(.hash) }}
+    .gnu.hash	: {{ *(.gnu.hash) }}
+    .dynsym		: {{ *(.dynsym) }}
+    .dynstr		: {{ *(.dynstr) }}
+    .gnu.version	: {{ *(.gnu.version) }}
+    .gnu.version_d	: {{ *(.gnu.version_d) }}
+    .gnu.version_r	: {{ *(.gnu.version_r) }}
 
-        /* 动态段单独分配 */
-        .dynamic    : {{ *(.dynamic) }}
+    /* 动态段单独分配 */
+    .dynamic    : {{ *(.dynamic) }}
 
-        . = ALIGN(16);
-        /* 代码段（.text）需要放在只读数据段之前 */
-        .text       : {{
-            *(.text.start)
-            *(.text .text.*)
-        }}
-
-        . = ALIGN(4K);
-        /* 只读数据段（.rodata等） */
-        .rodata     : {{
-            *(.rodata .rodata.* .gnu.linkonce.r.*)
-            *(.note.*)
-        }}
-
-        . = ALIGN(4K);
-        .plt : {{ *(.plt .plt.*) }}
-
-        . = ALIGN(4K);
-        /* 数据段（.data、.bss等）单独分配 */
-        .data       : {{
-            *(.data .data.* .gnu.linkonce.d.*)
-            *(.got.plt) *(.got)
-        }}
-
-        . = ALIGN(4K);
-        .bss        : {{
-            *(.bss .bss.* .gnu.linkonce.b.*)
-            *(COMMON)
-        }}
-
-        .eh_frame_hdr	: {{ *(.eh_frame_hdr) }}
-    	.eh_frame	: {{ KEEP (*(.eh_frame)) }}
+    . = ALIGN(16);
+    /* 代码段（.text）需要放在只读数据段之前 */
+    .text       : {{
+        *(.text.start)
+        *(.text .text.*)
     }}
-    "#,
+
+    . = ALIGN(4K);
+    /* 只读数据段（.rodata等） */
+    .rodata     : {{
+        *(.rodata .rodata.* .gnu.linkonce.r.*)
+        *(.note.*)
+    }}
+
+    . = ALIGN(4K);
+    .plt : {{ *(.plt .plt.*) }}
+
+    . = ALIGN(4K);
+    /* 数据段（.data、.bss等）单独分配 */
+    .data       : {{
+        *(.data .data.* .gnu.linkonce.d.*)
+        *(.got.plt) *(.got)
+    }}
+
+    . = ALIGN(4K);
+    .bss        : {{
+        *(.bss .bss.* .gnu.linkonce.b.*)
+        *(COMMON)
+    }}
+
+    .eh_frame_hdr	: {{ *(.eh_frame_hdr) }}
+    .eh_frame	: {{ KEEP (*(.eh_frame)) }}
+}}
+"#,
         arch_lds
     );
     linker
 }
 
-/// 编译vdso库为so文件，并拷贝到输出目录
+/// 先编译为静态库，再单独链接成 so。
 fn build_so(config: &BuildConfig) {
-    let absolute_script_dir = fs::canonicalize(Path::new(&config.out_dir).join("vdso_linker.lds"))
+    // 获取输出目录和生成链接脚本路径
+    let out_dir = Path::new(&config.out_dir);
+    let absolute_script_dir = fs::canonicalize(out_dir.join("vdso_linker.lds"))
         .unwrap()
         .display()
         .to_string();
-    let rustflags = format!(
-        "-C link-arg=-fpie -C link-arg=-soname={} -C link-arg=-T{}",
-        &config.so_name, absolute_script_dir
-    ); // 由于cargo在另外的目录执行，因此需要传入绝对路径
-    println!("RUSTFLAGS: {}", rustflags);
-    let build_target = match config.arch.as_str() {
-        "x86_64" => "x86_64-unknown-linux-musl",
-        "aarch64" => "aarch64-unknown-linux-musl",
-        "riscv64" => "riscv64gc-unknown-linux-musl",
-        _ => panic!("Unsupported arch"),
-    };
-    let linker = match config.arch.as_str() {
-        "x86_64" => "x86_64-linux-musl-ld",
-        "aarch64" => "aarch64-linux-musl-ld",
-        "riscv64" => "riscv64-linux-musl-ld",
-        _ => panic!("Unsupported arch"),
-    };
-    let linker_config = format!("target.{}.linker = \"{}\"", build_target, linker);
+    // 生成版本脚本
+    let version_script_path = out_dir.join("vdso_version.map");
+    fs::write(&version_script_path, version_script_content(config)).unwrap();
+
+    // 获取编译目标和链接器程序
+    let build_target = build_target(&config.arch);
+    let linker = linker_program(&config.arch);
+    // 获取是否为release模式
     let build_mode = match config.mode.as_str() {
         "debug" => "",
         "release" => "--release",
         _ => panic!("Unsupported mode"),
     };
+    // 获取编译输出的冗长程度
     let build_verbose = match config.verbose {
         0 => "",
         1 => "-v",
         2 => "-vv",
         _ => panic!("Unsupported verbose level"),
     };
-    fs::create_dir_all(Path::new(&config.out_dir).join("target")).unwrap();
-    let absolute_build_target_dir = fs::canonicalize(Path::new(&config.out_dir).join("target"))
+    // 获取.a输出目录
+    fs::create_dir_all(out_dir.join("target")).unwrap();
+    let absolute_build_target_dir = fs::canonicalize(out_dir.join("target"))
         .unwrap()
         .display()
         .to_string();
+    // 三元组参数
     let toolchain_arg = format!("+{}", &config.toolchain);
+
     let mut cargo_args = vec![
         &toolchain_arg,
-        "--config",
-        &linker_config,
         "build",
         "-Z",
         "unstable-options",
@@ -184,20 +197,21 @@ fn build_so(config: &BuildConfig) {
     }
     let mut cargo = Command::new("cargo");
 
+    // 添加环境变量，过滤掉以CARGO或RUST开头的环境变量
     cargo.env_clear();
     for (key, value) in env::vars() {
         if !(key.starts_with("CARGO") || key.starts_with("RUST")) {
             cargo.env(key, value);
         }
     }
-    let wrapper_dir = Path::new(&config.out_dir).join("vdso_wrapper");
-    cargo
-        .current_dir(&wrapper_dir)
-        .env("ARCH", &config.arch)
-        .env("RUSTFLAGS", rustflags)
-        .args(cargo_args);
+
+    // wrappper输出目录
+    let wrapper_dir = out_dir.join("vdso_wrapper");
+    // 构建编译命令
+    cargo.current_dir(&wrapper_dir).env("ARCH", &config.arch).args(cargo_args);
     println!("----------------cargo command----------------");
     println!("{:?}", &cargo);
+    // output()会触发执行命令并等待完成
     let cargo_output = cargo.output().expect("Failed to execute cargo build");
     println!("-----------------cargo stdout----------------");
     stdout().write_all(&cargo_output.stdout).unwrap();
@@ -207,29 +221,75 @@ fn build_so(config: &BuildConfig) {
         panic!("cargo build failed");
     }
 
-    let mut objcopy = Command::new("rust-objcopy");
-    // let src_filename = String::from("lib") + &config.package_name;
+    // 获取.a路径
     let src_file = Path::new(&absolute_build_target_dir)
         .join(build_target)
         .join(&config.mode)
         .join("libvdso_wrapper")
-        .with_extension("so")
+        .with_extension("a")
         .display()
         .to_string();
+    // 目标so路径
     let dst_file = Path::new(&config.out_dir)
         .join(&config.so_name)
         .with_extension("so")
         .display()
         .to_string();
-    objcopy.args(["-X", &src_file, &dst_file]);
-    println!("---------------objcopy command---------------");
-    println!("{:?}", &objcopy);
-    let objcopy_output = objcopy.output().expect("Failed to execute rust-objcopy");
-    println!("----------------objcopy stdout---------------");
-    stdout().write_all(&objcopy_output.stdout).unwrap();
-    println!("----------------objcopy stderr---------------");
-    stderr().write_all(&objcopy_output.stderr).unwrap();
-    if !objcopy_output.status.success() {
-        panic!("objcopy failed");
+    let mut linker_cmd = Command::new(linker);
+    // 链接命令参数
+    linker_cmd.args([
+        "-shared",
+        "-soname",
+        &config.so_name,
+        "-T",
+        &absolute_script_dir,
+        "--version-script",
+        version_script_path
+            .to_str()
+            .expect("version script 不是有效 UTF-8"),
+        "--gc-sections",
+        "--whole-archive",
+        &src_file,
+        "--no-whole-archive",
+        "-o",
+        &dst_file,
+    ]);
+    println!("---------------linker command---------------");
+    println!("{:?}", &linker_cmd);
+    let linker_output = linker_cmd.output().expect("Failed to execute vDSO linker");
+    println!("----------------linker stdout----------------");
+    stdout().write_all(&linker_output.stdout).unwrap();
+    println!("----------------linker stderr----------------");
+    stderr().write_all(&linker_output.stderr).unwrap();
+    if !linker_output.status.success() {
+        panic!("linker failed");
     }
+}
+
+fn version_script_content(config: &BuildConfig) -> String {
+    let mut symbols = exported_symbols(config);
+    symbols.sort();
+    symbols.dedup();
+
+    let mut content = String::from("vdso {\n    global:\n");
+    for symbol in symbols {
+        content.push_str("        ");
+        content.push_str(&symbol);
+        content.push_str(";\n");
+    }
+    content.push_str("    local:\n        *;\n};\n");
+    content
+}
+
+fn exported_symbols(config: &BuildConfig) -> Vec<String> {
+    let api_rs_path = Path::new(&config.src_dir).join("src").join("api.rs");
+    let api_source = fs::read_to_string(&api_rs_path).unwrap();
+    let re = regex::Regex::new(
+        r#"(?s)#\[unsafe\(no_mangle\)\]\s*pub\s+extern\s+\"C\"\s+fn\s+([A-Za-z0-9_]+)\s*\("#,
+    )
+    .unwrap();
+
+    re.captures_iter(&api_source)
+        .map(|capture| capture[1].to_string())
+        .collect()
 }


### PR DESCRIPTION
- 将编译cdylib(.so)的过程修改为先编译成staticlib(.a)，然后再用musl-ld链接成.so，绕过x86_64和aarch64的rust musl工具链无法编译cdylib的问题
- 修改riscv64, x86_64, aarch64使用no_std三元组，因为vdso理应不使用std