### PR TITLE
fix: fix panic: Relocate pair found in text section!

### DIFF
--- a/build_vdso/src/lib.rs
+++ b/build_vdso/src/lib.rs
@@ -84,53 +84,58 @@ fn gen_linker_script(arch: &str) -> String {
     let linker = format!(
         r#"OUTPUT_ARCH({})
 
+PHDRS {{
+    /* 首个 LOAD 段需要覆盖 ELF 头和程序头，保证生成的 DYN 镜像仍从 vaddr 0 开始装载。 */
+    text PT_LOAD FILEHDR PHDRS FLAGS(5);
+    /* 只读、不可执行的数据独立成段，避免 loader 将其误判为可共享的代码页。 */
+    rodata PT_LOAD FLAGS(4);
+    /* 动态信息、.data 和 .bss 使用可写段承载。 */
+    data PT_LOAD FLAGS(6);
+    dynamic PT_DYNAMIC FLAGS(6);
+}}
+
 SECTIONS {{
     . = SIZEOF_HEADERS;
 
-    /* 先放置动态链接相关的只读段 */
-    .hash		: {{ *(.hash) }}
-    .gnu.hash	: {{ *(.gnu.hash) }}
-    .dynsym		: {{ *(.dynsym) }}
-    .dynstr		: {{ *(.dynstr) }}
-    .gnu.version	: {{ *(.gnu.version) }}
-    .gnu.version_d	: {{ *(.gnu.version_d) }}
-    .gnu.version_r	: {{ *(.gnu.version_r) }}
-
-    /* 动态段单独分配 */
-    .dynamic    : {{ *(.dynamic) }}
-
-    . = ALIGN(16);
-    /* 代码段（.text）需要放在只读数据段之前 */
+    /* 代码段单独放在可执行 PT_LOAD 中，以便后续地址空间直接共享。 */
     .text       : {{
         *(.text.start)
         *(.text .text.*)
-    }}
+    }} :text
 
     . = ALIGN(4K);
-    /* 只读数据段（.rodata等） */
+    /* 动态链接元数据和只读常量放在只读段中，避免 text relocation 检查误报。 */
+    .hash		: {{ *(.hash) }} :rodata
+    .gnu.hash	: {{ *(.gnu.hash) }} :rodata
+    .dynsym		: {{ *(.dynsym) }} :rodata
+    .dynstr		: {{ *(.dynstr) }} :rodata
+    .gnu.version	: {{ *(.gnu.version) }} :rodata
+    .gnu.version_d	: {{ *(.gnu.version_d) }} :rodata
+    .gnu.version_r	: {{ *(.gnu.version_r) }} :rodata
     .rodata     : {{
         *(.rodata .rodata.* .gnu.linkonce.r.*)
         *(.note.*)
-    }}
+    }} :rodata
 
     . = ALIGN(4K);
-    .plt : {{ *(.plt .plt.*) }}
+    .plt : {{ *(.plt .plt.*) }} :rodata
+    .rela.dyn   : {{ *(.rela.dyn) }} :rodata
+    .eh_frame_hdr	: {{ *(.eh_frame_hdr) }} :rodata
+    .eh_frame	: {{ KEEP (*(.eh_frame)) }} :rodata
 
     . = ALIGN(4K);
-    /* 数据段（.data、.bss等）单独分配 */
+    /* 动态段和可写数据统一放到可写 PT_LOAD 中。 */
+    .dynamic    : {{ *(.dynamic) }} :data :dynamic
     .data       : {{
         *(.data .data.* .gnu.linkonce.d.*)
         *(.got.plt) *(.got)
-    }}
+    }} :data
 
     . = ALIGN(4K);
     .bss        : {{
         *(.bss .bss.* .gnu.linkonce.b.*)
         *(COMMON)
-    }}
-
-    .eh_frame_hdr	: {{ *(.eh_frame_hdr) }}
-    .eh_frame	: {{ KEEP (*(.eh_frame)) }}
+    }} :data
 }}
 "#,
         arch_lds

--- a/example/user_test/build.rs
+++ b/example/user_test/build.rs
@@ -16,7 +16,7 @@ fn main() {
     config.so_name = String::from("libvdsoexample");
     config.api_lib_name = String::from("libvdsoexample");
     config.out_dir = String::from("../../output");
-    config.toolchain = String::from("nightly-2025-09-12");
+    config.toolchain = String::from("nightly-2025-12-12");
     config.verbose = 2;
     build_vdso(&config);
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,9 +1,9 @@
 [toolchain]
 profile = "minimal"
-channel = "nightly-2025-09-30"
+channel = "nightly-2025-12-12"
 components = ["rust-src", "llvm-tools", "rustfmt", "clippy"]
 targets = [
-    "x86_64-unknown-linux-musl",
-    "aarch64-unknown-linux-musl",
+    #"x86_64-unknown-linux-musl",
+    #"aarch64-unknown-linux-musl",
     "riscv64gc-unknown-linux-musl",
 ]


### PR DESCRIPTION
在移植StarryOS中总是出现这个报错，经过排查应该是库文件问题。针对这个问题进行修改
所有的修改位置都在./build_vdso/src/lib.rs中
拆分 text/rodata/data 的 PT_LOAD 并让首段包含 FILEHDR/PHDRS，避免用户态复用映射时将只读段 relocation 误判为 text relocation